### PR TITLE
CI: add cronjob to run the CI daily

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
       - releases/*
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * *'
 
 jobs:
   nsolid-version:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow to support manual triggering and scheduled daily runs at 07:00 UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->